### PR TITLE
Add ESP32-S3 support and update version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,8 @@ jobs:
             platform-name: esp8266:esp8266
           - fqbn: "esp32:esp32:esp32"
             platform-name: esp32:esp32
+          - fqbn: "esp32:esp32:esp32s3"
+            platform-name: esp32:esp32
 
         library:
           - name: ArduinoJsonV6
@@ -153,6 +155,8 @@ jobs:
           - fqbn: "esp8266:esp8266:generic"
             platform-name: esp8266:esp8266
           - fqbn: "esp32:esp32:esp32"
+            platform-name: esp32:esp32
+          - fqbn: "esp32:esp32:esp32s3"
             platform-name: esp32:esp32
 
         include:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/Hieromon/AutoConnect)](https://github.com/Hieromon/AutoConnect/releases)
 [![Build Status](https://github.com/Hieromon/AutoConnect/actions/workflows/build.yml/badge.svg)](https://github.com/Hieromon/AutoConnect/actions/workflows/build.yml)
 [![arduino-library-badge](https://www.ardu-badge.com/badge/AutoConnect.svg?)](https://www.ardu-badge.com/AutoConnect)
-[![PlatformIO Registry](https://badges.registry.platformio.org/packages/hieromon/library/AutoConnect.svg?version=1.4.2)](https://registry.platformio.org/packages/libraries/hieromon/AutoConnect?version=1.4.2) 
+[![PlatformIO Registry](https://badges.registry.platformio.org/packages/hieromon/library/AutoConnect.svg?version=1.4.3)](https://registry.platformio.org/packages/libraries/hieromon/AutoConnect?version=1.4.3)
 [![License](https://img.shields.io/github/license/Hieromon/AutoConnect)](https://github.com/Hieromon/AutoConnect/blob/master/LICENSE)
 
 An Arduino library for ESP8266/ESP32 WLAN configuration at run time with web interface. 
@@ -102,6 +102,10 @@ Full documentation is available on https://Hieromon.github.io/AutoConnect, some 
 - [FAQ](https://hieromon.github.io/AutoConnect/faq.html).
 
 ## Change log
+
+### [1.4.3] Jun. 28, 2025
+- Added continuous integration builds for ESP32-S3 boards.
+- Updated dependencies to use ArduinoJson v6 and PageBuilder v1.6 or later.
 
 ### [1.4.2] Jan. 31, 2023
 - Supports whileConnecting exit called while waiting for WiFi connection. (Discussions [#553](https://github.com/Hieromon/AutoConnect/issues/553))

--- a/library.json
+++ b/library.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "PageBuilder",
-      "version": ">=1.5.6"
+      "version": ">=1.6.0"
     },
     {
       "name": "ArduinoJson",
-      "version": ">=5.13.3"
+      "version": ">=6.21.2"
     }
   ],
   "frameworks": "arduino",
@@ -22,7 +22,7 @@
     "espressif8266",
     "espressif32"
   ],
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "headers": [
     "AutoConnect.h",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AutoConnect
-version=1.4.2
+version=1.4.3
 author=Hieromon Ikasamo <hieromon@gmail.com>
 maintainer=Hieromon Ikasamo <hieromon@gmail.com>
 sentence=ESP8266/ESP32 WLAN configuration at runtime with web interface.
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/Hieromon/AutoConnect.git
 architectures=esp8266, esp32
 includes=AutoConnect.h
-depends=ArduinoJson, PageBuilder
+depends=ArduinoJson>=6.21.2, PageBuilder>=1.6.0

--- a/mkdocs/changelog.md
+++ b/mkdocs/changelog.md
@@ -1,3 +1,11 @@
+### [1.4.3] Jun. 28, 2025
+
+#### Enhancements
+
+- Added continuous integration builds for ESP32-S3 boards.
+- Updated dependency requirements to ArduinoJson v6 and PageBuilder v1.6 or later.
+
+---
 ### [1.4.2] Jan. 31, 2023
 
 #### Enhancements


### PR DESCRIPTION
## Summary
- bump version to 1.4.3 and require newer dependencies
- document changes in README and mkdocs
- update PlatformIO badge
- extend CI workflow with esp32s3 board

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685f39131a30832ca7b1a0a914deb781